### PR TITLE
Loading Icon More Visible When Changing Views

### DIFF
--- a/administrator/components/com_cck/assets/css/ui.css
+++ b/administrator/components/com_cck/assets/css/ui.css
@@ -394,6 +394,7 @@ ul.spe span.variation_value{line-height: 24px;}
 ul.adminformlist span.state{margin-top:8px;}
 ul.adminformlist a > span.state{margin-top:0;}
 .loading{position:absolute; right:50px; top:63px;}
+.loading img {padding: 9px 15px;background: #16396f;border-radius: 2px;}
 body:not(.admin):not(.component) ul.spe_description a:link,
 body:not(.admin):not(.component) ul.spe_description a:visited,
 body:not(.admin):not(.component) ul.spe_third a:link,


### PR DESCRIPTION
Changing between Admin to Site form has the icon showing, but not very clearly.
This makes it more visible and in keeping with the Seblod Theme,